### PR TITLE
If Alt/Option modifier is used, open search result in new tab

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,4 +1,4 @@
-window.addEventListener("keydown", function handleNavigation (event) {
+window.addEventListener("keypress", function handleNavigation (event) {
     if (window.document.activeElement !== window.document.body) {
         return;
     }
@@ -25,7 +25,11 @@ window.addEventListener("keydown", function handleNavigation (event) {
     const anchor = result.querySelector("a");
     const href = anchor.href;
 
-    window.location.href = href;
+    if (event.altKey) {
+        window.open(href, "_blank");
+    } else {
+        window.location.href = href;
+    }
 }, true);
 
 const emojicationSuffix = "\u{FE0F}\u{20e3} ";


### PR DESCRIPTION
I like to be able to select a result but leave the search results tab intact.

Alt seems like an appropriate modifier?  Ctrl and Command (w/ digits) are more likely to be used by the OS/Browser. 

Does this affect the required permissions of the extension (ie, opening a new tab)?