### PR TITLE
Fix result selection with 0 hotkey

### DIFF
--- a/main.js
+++ b/main.js
@@ -13,8 +13,9 @@ window.addEventListener("keydown", function handleNavigation (event) {
         return;
     }
 
-    const index = (digit === 0) ? 8 : (digit - 1);
     const results = document.body.querySelectorAll("h3");
+    const last = results.length - 1;
+    const index = (digit === 0) ? last : (digit - 1);
     const result = results[index];
     if (!result) {
         return;
@@ -23,6 +24,9 @@ window.addEventListener("keydown", function handleNavigation (event) {
     event.stopPropagation();
 
     const anchor = result.closest("a");
+    if (!anchor) {
+        return;
+    }
     const href = anchor.href;
 
     window.location.href = href;


### PR DESCRIPTION
## Summary
- fix index used when pressing the `0` hotkey
- avoid error if a result isn't contained in an anchor

## Testing
- `node --check main.js`


------
https://chatgpt.com/codex/tasks/task_e_684ecb922d7483319b2421775260c86e